### PR TITLE
chore: makes use of eth_chainId

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -521,36 +521,6 @@
             </div>
           </div>
         </div>
-
-        <div
-            class="col-xl-4 col-lg-6 col-md-12 col-sm-12 col-12 d-flex align-items-stretch"
-          >
-            <div class="card full-width">
-              <div class="card-body">
-                <h4 class="card-title">
-                  Sign in to compliance
-                </h4>
-
-                <p class="info-text alert alert-success">
-                  Project ID: <input name="compliance-project-id" id="complianceProjectId" value="ded5f9c0-e55c-4c0a-ac86-3dd513e876f0" />
-                  &nbsp;
-                  Client ID: <input name="compliance-client-id" id="complianceClientId" value="5kQHg48BQJR2QuGTs1EX4V5OJZI8RA2k" />
-                </p>
-
-                <button
-                  class="btn btn-primary btn-lg btn-block mb-3"
-                  id="complianceButton"
-                 >
-                  Add token
-                </button>
-
-                <p class="info-text alert alert-secondary">
-                  Result: <span id="complianceResult">Not clicked</span>
-                </p>
-
-              </div>
-            </div>
-          </div>
       </section>
       
     </main>

--- a/src/index.js
+++ b/src/index.js
@@ -95,11 +95,6 @@ const signTypedDataV4Verify = document.getElementById('signTypedDataV4Verify')
 const signTypedDataV4VerifyResult = document.getElementById('signTypedDataV4VerifyResult')
 
 const signTypedContentsId = document.getElementById('signTypedContentsId')
-const complianceProjectId = document.getElementById('complianceProjectId')
-const complianceClientId = document.getElementById('complianceClientId')
-
-const complianceButton = document.getElementById('complianceButton')
-const complianceResult = document.getElementById('complianceResult')
 
 const disableSections = (disable) => {
   for (let i = 0; i < sectionClass.length; i++) {
@@ -221,7 +216,7 @@ const initialize = async () => {
 
   const updateButtons = async () => {
     const networkId = Number(await ethereum.request({
-      method: 'net_version',
+      method: 'eth_chainId',
     }))
     const accountButtonsDisabled = !isMetaMaskInstalled() || !isMetaMaskConnected() || networkId === 1
     if (accountButtonsDisabled) {
@@ -933,40 +928,6 @@ const initialize = async () => {
     }
   }
 
-  complianceButton.onclick = async () => {
-    const projectId = complianceProjectId.value
-    const clientId = complianceClientId.value
-
-    try {
-      const result = await window.ethereum.request({
-        'method': 'metamaskinstitutional_authenticate',
-        'params': {
-          'origin': 'mmitest.compliance.codefi.network',
-          'token': {
-            clientId,
-            projectId,
-          },
-          'feature': 'compliance',
-          'service': 'codefi-compliance',
-          'labels': [
-            {
-              'key': 'service',
-              'value': 'Codefi Compliance',
-            },
-            {
-              'key': 'token.projectId',
-              'value': 'Some project name',
-            },
-          ],
-        },
-      })
-
-      complianceResult.innerHTML = result
-    } catch (err) {
-      complianceResult.innerHTML = `Error: ${err.message}`
-    }
-  }
-
   function handleNewAccounts(newAccounts) {
     accounts = newAccounts
     accountsDiv.innerHTML = accounts
@@ -993,7 +954,7 @@ const initialize = async () => {
       handleNewChain(chainId)
 
       const networkId = await ethereum.request({
-        method: 'net_version',
+        method: 'eth_chainId',
       })
       handleNewNetwork(networkId)
     } catch (err) {


### PR DESCRIPTION
Due to a package update on the extension, the rpc request for `net_version` throws a bunch of errors, making the test dapp unusable, therefore we updated the method to use the `eth_chainId` instead which was and is working fine.

Also removed some code that is not needed anymore.